### PR TITLE
kalabox/kalabox#1228 - Changed syncthing to try starting if a restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,5 @@ v0.12.0-alpha23
 * Changed syncthing rescan interval to always be 2 seconds. [#1199](https://github.com/kalabox/kalabox/issues/1199)
 
 * Implemented app specific status messages. [#1255](https://github.com/kalabox/kalabox/issues/1255)
+
+* Changed syncthing to try starting if a restart has failed to put it in the up state. This was usually encountered when running multiple app actions in the GUI. [#1228](https://github.com/kalabox/kalabox/issues/1228)

--- a/plugins/kalabox-sharing/lib/share/sync.js
+++ b/plugins/kalabox-sharing/lib/share/sync.js
@@ -154,7 +154,7 @@ module.exports = function(kbox) {
 
     // Run recursive function until it returns or a timeout is reached.
     return rec()
-    .timeout(120 * 1000)
+    .timeout(30 * 1000)
     // Wrap errors.
     .catch(function(err) {
       throw new VError(err,
@@ -352,7 +352,12 @@ module.exports = function(kbox) {
     return self.restart()
     // Wait until it becomes responsive.
     .then(function() {
-      return self.wait();
+      return self.wait()
+      // If wait failed, then we can assume syncthing failed to restart and is
+      // in a stopped state so try to start it again.
+      .catch(function() {
+        return self.start();
+      });
     })
     // Log successful restarting.
     .then(function() {


### PR DESCRIPTION
Thank you so much for contributing code to Kalabox!

We will get to your PR as soon as we can but in the meantime you might want to
check to make sure you have done the following. **The more boxes you can check
the easier it will be for us to merge in your changes with confidence**
- [x] My code passes relevant CI status checks
- [ ] My code includes a test ([see here](https://github.com/kalabox/kalabox-cli/blob/HEAD/CONTRIBUTING.md))
- [x] My code includes an update to `CHANGELOG.md` ([see here](https://github.com/kalabox/kalabox-cli/blob/HEAD/CHANGELOG.md))
- [x] My code includes documentation updates if relevant.
- [x] I have pinged @rileysaurus when I think my code is ready for prime time.

If you are unclear about any of the above please add comments below so we can
improve our process.

has failed to put it in the up state. This was usually encountered when
running multiple app actions in the GUI.
