### PR TITLE
Disregard hyphens when checking to see if a duplicate app exists.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,5 @@ v0.12.0-alpha23
 * Changed app destroy action to remove the app's directory. [#1232](https://github.com/kalabox/kalabox/issues/1232)
 
 * Added kalabox-ui plugin which manages a token container to enable app state and events via docker events stream. [#1160](https://github.com/kalabox/kalabox/issues/1160)
+
+* Disregard hyphens when checking if an app already exists with app.exists(appName).

--- a/lib/app.js
+++ b/lib/app.js
@@ -394,7 +394,7 @@ var get = exports.get = function(appName, callback) {
  */
 var exists = exports.exists = function(appName, callback) {
   // Get app.
-  return get(appName)
+  return get(appName.replace(/-/g, ''))
   // Return false if we get an app does not exist error.
   .catch(function(err) {
     if (_.contains(err.message, ' does not exist.')) {


### PR DESCRIPTION
- [x] My code passes relevant CI status checks
- [ ] My code includes a test ([see here](https://github.com/kalabox/kalabox-cli/blob/HEAD/CONTRIBUTING.md))
- [x] My code includes an update to `CHANGELOG.md` ([see here](https://github.com/kalabox/kalabox-cli/blob/HEAD/CHANGELOG.md))
- [x] My code includes documentation updates if relevant.
- [x] I have pinged @rileysaurus when I think my code is ready for prime time.

If you are unclear about any of the above please add comments below so we can
improve our process.
