### PR TITLE
kalabox/kalabox#1285 - Removing code no longer needed that was resulting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ v0.12.0-alpha24
 * Disregard hyphens when checking if an app already exists with app.exists(appName).
 * Changed docker events query to include all events since docker was started. [#1290](https://github.com/kalabox/kalabox/issues/1290)
 * Fixed testing to use new `cgroup-bin` pkg instead of `cgroup-lite`
+* Removing code no longer needed that was resulting in duplicate 'Pulling image <image_name>' messages in the cli. [#1285](https://github.com/kalabox/kalabox/issues/1285)
 
 #### App updates
 

--- a/lib/core/log.js
+++ b/lib/core/log.js
@@ -16,32 +16,6 @@ var Log = require('../util/log.js');
 var log = new Log();
 
 /*
- * Register plugins.
- */
-log.use(function(kind, message) {
-  // Only check non status events so we don't get into an infinite loop, so
-  // we don't get into an infinite loop, so we don't get into an infinite loop,
-  // so we dont' get into an infinite loop.
-  if (kind !== 'status') {
-    // Update status when pulling an image.
-    var images = message.match(/Pulling from (.*)/);
-    if (images) {
-      log.status('Pulling image %s.', images[1]);
-    }
-    // Update status based on some logging data.
-    if (message.match(/Downloading .*boot2docker.iso/)) {
-      log.status('Downloading ISO.');
-    } else if (message.match(/Creating VirtualBox VM/)) {
-      log.status('Creating VM.');
-    } else if (message.match(/Starting the VM/)) {
-      log.status('Starting VM.');
-    } else if (message.match(/Provisioning with boot2docker/)) {
-      log.status('Provisioning Docker.');
-    }
-  }
-});
-
-/*
  * Export singleton instance.
  */
 module.exports = log;


### PR DESCRIPTION
Thank you so much for contributing code to Kalabox!

We will get to your PR as soon as we can but in the meantime you might want to
check to make sure you have done the following. **The more boxes you can check
the easier it will be for us to merge in your changes with confidence**
- [x] My code passes relevant CI status checks
- [ ] My code includes a test ([see here](https://github.com/kalabox/kalabox-cli/blob/HEAD/CONTRIBUTING.md))
- [x] My code includes an update to `CHANGELOG.md` ([see here](https://github.com/kalabox/kalabox-cli/blob/HEAD/CHANGELOG.md))
- [x] My code includes documentation updates if relevant.
- [x] I have pinged @rileysaurus when I think my code is ready for prime time.

If you are unclear about any of the above please add comments below so we can
improve our process.

in duplicate 'Pulling image <image_name>' messages in the cli.
